### PR TITLE
Op locking

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,7 @@
 
 <script>
 
+  import { computed } from 'vue'
   import { useCookies } from "vue3-cookies";
 
   // Utility panels
@@ -154,6 +155,15 @@
         configs: configs,
         mainMode: 'config',
         errorInfo: null,
+        accessLevel: 0,
+      }
+    },
+    provide() {
+      return {
+        accessLevel: computed({
+          get: () => this.accessLevel,
+          set: (v) => {this.accessLevel = v;}
+        })
       }
     },
     components: {
@@ -199,6 +209,7 @@
         this.mainMode = 'agent';
         this.active_agent = v;
         this.force_generic = debug;
+        this.accessLevel = 1;
       },
       setMode(mode) {
         this.mainMode = mode;

--- a/src/components/OcsProcess.vue
+++ b/src/components/OcsProcess.vue
@@ -3,8 +3,12 @@
     <form v-on:submit.prevent>
       <div class="ocs_row">
         <label class="important">{{ name }}</label>
-        <button @click="start">Start</button>
-        <button @click="stop">Stop</button>
+        <button
+          :disabled="accessLevel < 1"
+          @click="start">Start</button>
+        <button
+          :disabled="accessLevel < 1"
+          @click="stop">Stop</button>
       </div>
 
       <slot></slot>
@@ -32,6 +36,7 @@
         default: true,
       },
     },
+    inject: ['accessLevel'],
     computed: {
       comp_status() {
         return window.ocs_bundle.web.get_status_string(

--- a/src/components/OcsTask.vue
+++ b/src/components/OcsTask.vue
@@ -3,7 +3,9 @@
     <form v-on:submit.prevent>
       <div class="ocs_row">
         <label class="important">{{ name }}</label>
-        <button @click="start">Start</button>
+        <button
+          :disabled="accessLevel < 1"
+          @click="start">Start</button>
         <span></span>
       </div>
 
@@ -32,6 +34,7 @@
         default: true,
       },
     },
+    inject: ['accessLevel'],
     computed: {
       comp_status() {
         return window.ocs_bundle.web.get_status_string(

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import OpStatus       from './components/OpStatus.vue'
 import OpSelect       from './components/OpDropdown.vue'
 import ProgressBar    from './components/ProgressBar.vue'
 import OcsOpAutofill  from './components/OcsOpAutofill.vue'
+import OpLocker       from './components/OpLocker.vue'
 
 app
   .component('OcsTask',     OcsTask)
@@ -24,7 +25,10 @@ app
   .component('OpSelect',    OpSelect)
   .component('ProgressBar', ProgressBar)
   .component('OcsOpAutofill', OcsOpAutofill)
+  .component('OpLocker',    OpLocker)
 ;
- 
+
+// This is needed in vue<3.3 to use computed function with provide/inject
+app.config.unwrapInjectedRef = true;
   
 app.mount('#app');

--- a/src/panels/AggregatorAgent.vue
+++ b/src/panels/AggregatorAgent.vue
@@ -5,7 +5,7 @@
     <!-- Left block -->
     <div class="block_unit">
       <div class="box">
-        <h1>Aggregator Agent</h1>
+        <h1>Aggregator Agent <OpLocker /></h1>
         <h2>Connection</h2>
         <OpReading
           caption="Address"

--- a/src/panels/GenericAgent.vue
+++ b/src/panels/GenericAgent.vue
@@ -5,7 +5,7 @@
     <!-- Left block -->
     <div class="block_unit">
       <div class="box">
-        <h1>Generic Control Panel</h1>
+        <h1>Generic Control Panel <OpLocker /></h1>
         <h2>Connection</h2>
         <OpReading
           caption="Address"

--- a/src/panels/HostManager.vue
+++ b/src/panels/HostManager.vue
@@ -5,7 +5,7 @@
     <!-- Left block -->
     <div class="block_unit">
       <div class="box">
-        <h1>Host Manager</h1>
+        <h1>Host Manager <OpLocker /></h1>
         <h2>Connection</h2>
         <OpReading caption="Address"
                  v-bind:value="address">
@@ -29,8 +29,8 @@
             <span>{{ item.agent_class }}</span>
             <span class="hm_center">{{ item.next_action }}</span>
             <span class="hm_center">{{ item.target_state }}</span>
-            <button @click="set_target(item.instance_id, 'up')">up</button>
-            <button @click="set_target(item.instance_id, 'down')">down</button>
+            <button :disabled="accessLevel < 1" @click="set_target(item.instance_id, 'up')">up</button>
+            <button :disabled="accessLevel < 1" @click="set_target(item.instance_id, 'down')">down</button>
           </div>
         </form>
       </div>
@@ -61,6 +61,7 @@
 
   export default {
     name: 'HostManager',
+    inject: ['accessLevel'],
     data: function () {
       return {
         connection_ok: false,

--- a/src/panels/Lakeshore372Agent.vue
+++ b/src/panels/Lakeshore372Agent.vue
@@ -5,7 +5,7 @@
     <!-- Left block -->
     <div class="block_unit">
       <div class="box">
-        <h1>Lakeshore372Agent</h1>
+        <h1>Lakeshore372Agent <OpLocker /></h1>
         <h2>Connection</h2>
         <OpReading
           caption="Address"
@@ -77,6 +77,7 @@
     props: {
       address: String,
     },
+    inject: ['accessLevel'],
     data: function () {
       return {
         extension: 5,

--- a/src/panels/Lakeshore372Agent.vue
+++ b/src/panels/Lakeshore372Agent.vue
@@ -38,7 +38,6 @@
       </OcsTask>
       <OcsTask
         :address="address"
-        @op_error="op_error"
         :op_data="ops.set_autoscan">
         <div class="ocs_row">
           <label>Set autoscan?</label>
@@ -121,11 +120,6 @@
           });
         }
         return new_data;
-      },
-    },
-    methods: {
-      op_error(text) {
-        this.$emit('op_error', text);
       },
     },
     mounted() {


### PR DESCRIPTION
It is now easy to add a little lock icon to a panel, and the start/stop buttons will be disabled until the lock is clicked.

Panel will re-lock after 30 seconds; or shift-click to unlock indefinitely.