### PR TITLE
Setup GitHub Actions workflow to build and publish Docker images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,50 @@
+name: Publish Docker Image to Registry
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: simonsobs/ocs-web
+  PULL_REQUEST: ${{ github.event_name == 'pull_request' }}  # true on PR
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push the Docker image
+        run: |
+          # Build image
+          docker build . --file Dockerfile --tag ${IMAGE_NAME}:latest
+
+          # Determine tag based on npm version within container
+          export DOCKER_TAG=$(docker run --rm --entrypoint=/usr/local/bin/npm ${IMAGE_NAME}:latest list ocs-web | head -n 1 | cut -d ' ' -f1 | cut -d '@' -f2)
+          echo "Docker Tag: ${DOCKER_TAG}"
+
+          # Tag image
+          docker tag ${IMAGE_NAME}:latest ${IMAGE_NAME}:${DOCKER_TAG}
+
+          # Push images only on push to main
+          if [[ "$PULL_REQUEST" != 'true' ]]; then
+            docker push ${IMAGE_NAME}:latest
+            docker push ${IMAGE_NAME}:${DOCKER_TAG}
+          else
+            :
+          fi

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ development rather than performance.
 
 To build the image and tag it as "ocs-web":
 ```
-docker build -t ocs-web
+docker build -t ocs-web .
 ```
 
 To launch the image as a test:
 ```
-docker run -p 8080:8080 --rm ocs-web
+docker run -p 8080:8080 --rm --env HOST=0.0.0.0 ocs-web
 ```
 
 Then browse to http://localhost:8080/
@@ -132,8 +132,7 @@ services:
     ports:
       - 8080:8080
     environment:
-      - OCS_ADDRS=My new lab,http://localhost:8080/ws,test_realm
-
+      - OCS_ADDRS=My new lab,ws://localhost:8080/ws,test_realm
 ```
 
 (These variables get appended to .env.local inside the container; if


### PR DESCRIPTION
This sets up a workflow to build docker images and publish them to Github's registry. It should build on all PRs and pushes to "main". It should also only publish on pushes to "main", not on PRs.

A version tag is pulled from the npm package file, and used to tag the docker image, but if we want to be more diligent about this probably we want to grab it some other way (i.e. do releases and based it on that tag.) But I think this is fine for now while panels are being developed.

This still somewhat needs to be tested, mostly that conditional publish, as I haven't done it exactly this way in other workflows before.