### PR TITLE
Fix docker image push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,19 +32,19 @@ jobs:
       - name: Build and push the Docker image
         run: |
           # Build image
-          docker build . --file Dockerfile --tag ${IMAGE_NAME}:latest
+          docker build . --file Dockerfile --tag ${REGISTRY}/${IMAGE_NAME}:latest
 
           # Determine tag based on npm version within container
-          export DOCKER_TAG=$(docker run --rm --entrypoint=/usr/local/bin/npm ${IMAGE_NAME}:latest list ocs-web | head -n 1 | cut -d ' ' -f1 | cut -d '@' -f2)
+          export DOCKER_TAG=$(docker run --rm --entrypoint=/usr/local/bin/npm ${REGISTRY}/${IMAGE_NAME}:latest list ocs-web | head -n 1 | cut -d ' ' -f1 | cut -d '@' -f2)
           echo "Docker Tag: ${DOCKER_TAG}"
 
           # Tag image
-          docker tag ${IMAGE_NAME}:latest ${IMAGE_NAME}:${DOCKER_TAG}
+          docker tag ${REGISTRY}/${IMAGE_NAME}:latest ${REGISTRY}/${IMAGE_NAME}:${DOCKER_TAG}
 
           # Push images only on push to main
           if [[ "$PULL_REQUEST" != 'true' ]]; then
-            docker push ${IMAGE_NAME}:latest
-            docker push ${IMAGE_NAME}:${DOCKER_TAG}
+            docker push ${REGISTRY}/${IMAGE_NAME}:latest
+            docker push ${REGISTRY}/${IMAGE_NAME}:${DOCKER_TAG}
           else
             :
           fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ocs-web
 
+[![build](https://img.shields.io/github/workflow/status/simonsobs/ocs-web/Publish%20Docker%20Image%20to%20Registry)](https://github.com/simonsobs/ocs-web/actions/workflows/build.yaml)
+
 ## Background
 
 This is browser-based control panel system for


### PR DESCRIPTION
While referencing two different workflows to make this one I omitted the use of the configured registry, so while we were logged into the GitHub registry we were trying to publish to DockerHub.

This fixes that. I'm going to test the push before saying we should merge this, perhaps in another temporary commit.