### PR TITLE
Fix mix tabs and spaces error

### DIFF
--- a/src/panels/ACUAgent.vue
+++ b/src/panels/ACUAgent.vue
@@ -267,7 +267,7 @@
               el_endpoint1: 60,
               el_endpoint2: 60,
               el_speed: 1,
-	      az_start: 'az_endpoint1',
+              az_start: 'az_endpoint1',
               ramp_up: null,
               wait_to_start: null,
               num_scans: null,


### PR DESCRIPTION
Seeing this error on a freshly compiled ocs-web on `main`:

```
Compiled with problems:

ERROR

/app/src/panels/ACUAgent.vue
  270:1  error  Mixed spaces and tabs  no-mixed-spaces-and-tabs

✖ 1 problem (1 error, 0 warnings)
```

I see this is fixed in #14, but if that's going to be a while before it's merged I think we should merge this fix.