### PR TITLE
Fix github actions workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ocs-web
 
-[![build](https://img.shields.io/github/workflow/status/simonsobs/ocs-web/Publish%20Docker%20Image%20to%20Registry)](https://github.com/simonsobs/ocs-web/actions/workflows/build.yaml)
+[![build](https://img.shields.io/github/actions/workflow/status/simonsobs/ocs-web/build.yaml?branch=main)](https://github.com/simonsobs/ocs-web/actions/workflows/build.yaml)
 
 ## Background
 


### PR DESCRIPTION
Quick fix for the GitHub Actions workflow badge. URL was changed upstream. See https://github.com/badges/shields/issues/8671.