### PR TITLE
Update build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,10 +44,10 @@ jobs:
           # Tag image
           docker tag ${REGISTRY}/${IMAGE_NAME}:latest ${REGISTRY}/${IMAGE_NAME}:${DOCKER_TAG}
 
-          # Push images only on push to main
-          if [[ "$PULL_REQUEST" != 'true' ]]; then
+          # Push images only on push to main or release
+          if [[ "$GITHUB_REF_NAME" = "main" || "$GITHUB_EVENT_NAME" = "release" ]]; then
             docker push ${REGISTRY}/${IMAGE_NAME}:latest
             docker push ${REGISTRY}/${IMAGE_NAME}:${DOCKER_TAG}
           else
-            :
+            echo "Skipping docker push; not on 'main' branch or a release."
           fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        # Grab tags during checkout
+        with:
+          fetch-depth: 0
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2
@@ -35,7 +38,7 @@ jobs:
           docker build . --file Dockerfile --tag ${REGISTRY}/${IMAGE_NAME}:latest
 
           # Determine tag based on npm version within container
-          export DOCKER_TAG=$(grep -e '"version":' package.json | xargs | cut -d ' ' -f2 | sed 's/,//g')
+          export DOCKER_TAG=$(git describe --tags --always)
           echo "Docker Tag: ${DOCKER_TAG}"
 
           # Tag image


### PR DESCRIPTION
This does two things:
* Bases the docker image tags on the git tags via `git describe --tags --always`
* Updates the conditional check for when to push images

This second change is to help facilitate testing workflow changes. Typically I'll just comment out line 5, which restricts the workflow to only run on pushes to "main", not just any branch. It's helpful sometimes to remove and trigger a run on a push before PR. However, this would still publish the Docker images.

Now we check that we're on the "main" branch before pushing. The other scenario when we'd want to push when not on "main" is if we're on a tagged release, so we also check if the `GITHUB_EVENT_NAME` is "release" and will push in that case as well.