### PR TITLE
Publish docker images on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,8 @@
 name: Publish Docker Image to Registry
 
 on:
+  release:
+    types: [ released ]
   push:
     branches: [ "main" ]
   pull_request:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,8 +48,14 @@ jobs:
 
           # Push images only on push to main or release
           if [[ "$GITHUB_REF_NAME" = "main" || "$GITHUB_EVENT_NAME" = "release" ]]; then
-            docker push ${REGISTRY}/${IMAGE_NAME}:latest
             docker push ${REGISTRY}/${IMAGE_NAME}:${DOCKER_TAG}
           else
             echo "Skipping docker push; not on 'main' branch or a release."
+          fi
+
+          # Push 'latest' only on release
+          if [[ "$GITHUB_EVENT_NAME" = "release" ]]; then
+            docker push ${REGISTRY}/${IMAGE_NAME}:latest
+          else
+            echo "Not tagging 'latest'; this is not a release."
           fi


### PR DESCRIPTION
This will trigger the workflow to run on release (as is done [in ocs](https://github.com/simonsobs/ocs/blob/cfa1f1ed6501a186aeb5b86062d0ad70083b0264/.github/workflows/deploy.yml#L4-L5).)

It also now only tags the special 'latest' tag on releases. Note that it still publishes on every commit to 'main', and won't publish on manual dispatches.