### PR TITLE
Address root

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,18 @@ The schema for config.json is like this::
 {"crossbars": [
     {"name": "ocs-8001",
      "url": "ws://localhost:8001/ws",
-     "realm": "test_realm"},
+     "realm": "test_realm",
+     "addr_root": "observatory"},
     {"name": "ocs-8002",
      "url": "ws://localhost:8002/ws",
-     "realm": "test_realm"}
+     "realm": "test_realm",
+     "addr_root": "platform2"}
     ]
 }
 ```
+
+Note that `realm` and `addr_root` are optional, and will default to
+values `test_realm` and `observatory`.
 
 
 ### Environment variables
@@ -94,20 +99,24 @@ for general info.)
 This variable carries zero or more "OCS configs".  Each "OCS config"
 is defined by a name (e.g. "My OCS"; this is only used in this
 application), the URL of the WAMP router's websocket server
-(e.g. "ws://example.com/crossbar/ws"), and the the realm
-(e.g. "ocsrealm").
+(e.g. "ws://example.com/crossbar/ws"), the WAMP realm
+(e.g. "ocsrealm"), and the OCS "address root" (e.g. "observatory").
 
-Each OCS config is constructed by joining those three things together
+Each OCS config is constructed by joining those four things together
 with commas; multiple OCS configs are separated by semicolons.  So the
 result should look like this:
 
 ```
-VUE_APP_OCS_ADDRS=My OCS,ws://example.com/crossbar/ws,ocsrealm
+VUE_APP_OCS_ADDRS=My OCS,ws://example.com/crossbar/ws,ocsrealm,observatory
 ```
+
+(If 3 or fewer tokens are specified, then the address root defaults to
+"observatory"; if only 2 tokens are specified then the realm defaults
+to "test_realm".)
 
 Here's a multi-config example:
 ```
-VUE_APP_OCS_ADDRS=Lab1,ws://localhost:8001/ws,test_realm;Lab2,ws://localhost:8002/ws,test_realm
+VUE_APP_OCS_ADDRS=Lab1,ws://localhost:8001/ws,test_realm;Lab2,ws://localhost:8002/ws,test_realm,platform2
 ```
 
 (In addition to these "static" OCS configs, the "custom" config is

--- a/src/App.vue
+++ b/src/App.vue
@@ -184,6 +184,7 @@
   window.ocs = new ocs.OCSConnection(
     function () {return window.ocs_bundle.config.url; },
     function () {return window.ocs_bundle.config.realm; },
+    function () {return window.ocs_bundle.config.addr_root; },
   );
 
   export default {
@@ -291,6 +292,8 @@
               cfg.url = cfg_cookie.url;
             if (cfg_cookie.realm)
               cfg.realm = cfg_cookie.realm;
+            if (cfg_cookie.addr_root)
+              cfg.addr_root = cfg_cookie.addr_root;
           }
         });
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 /* eslint-disable */
 <template>
-  <h1>Observatory Control System</h1>
+  <h1>{{ main_title }}</h1>
   <hr />
 
   <!-- Viewport-fixed for unscrollables-->
@@ -192,6 +192,7 @@
     data() {
       let [configs, index] = web.setup_configs();
       return {
+        main_title: 'Observatory Control System',
         active_agent: {
           'comp': null,
           'addr': null,
@@ -307,6 +308,8 @@
       }
       ocs_bundle.config = this.configs[this.config_index];
       window.ocs.start();
+
+      this.main_title = `Observatory Control System - [${ocs_bundle.config.name}]`;
 
       // Register error handler.
       ocs_bundle.on_error = (msg) => {

--- a/src/components/AgentList.vue
+++ b/src/components/AgentList.vue
@@ -18,9 +18,6 @@
   export default {
     name: 'AgentList',
     props: {
-      prefix: {
-        default: 'observatory.',
-      },
       parent_id: String,
       known_classes: Array,
     },
@@ -29,6 +26,7 @@
         tracked_agents: {},
         alphabetical: [],
         by_class: [],
+        addr_root: 'observatory',
       }
     },
     computed: {
@@ -42,8 +40,9 @@
       },
       update_agent_list(agent_addr, new_state, info) {
         let short = agent_addr;
-        if (short.startsWith(this.prefix))
-          short = short.slice(this.prefix.length);
+        let addr_root = window.ocs.agent_list.connection.addr_root_func();
+        if (addr_root && short.startsWith(addr_root + '.'))
+            short = short.slice(addr_root.length + 1);
         this.tracked_agents[agent_addr] = {
           addr: agent_addr,
           instance_id: short,

--- a/src/ocsbow.js
+++ b/src/ocsbow.js
@@ -11,10 +11,11 @@ export function init(ocs_bundle_) {
     ocs_bundle = ocs_bundle_;
 }
 
-export function OCSConnection(url_func, realm_func)
+export function OCSConnection(url_func, realm_func, addr_root_func)
 {
     this.url_func = url_func;
     this.realm_func = realm_func;
+    this.addr_root_func = addr_root_func;
 
     // Hooks; assign handlers with .on(trigger, func).
     this.handlers = {
@@ -47,6 +48,9 @@ OCSConnection.prototype = {
         var this_ocs = this;
         var url = this.url_func();
         var realm = this.realm_func();
+        var addr_root = 'observatory';
+        if (this.addr_root_func)
+            addr_root = this.addr_root_func();
 
         // See connection options at...
         // https://github.com/crossbario/autobahn-js/blob/master/packages/autobahn/lib/connection.js
@@ -67,7 +71,7 @@ OCSConnection.prototype = {
                 this_ocs.handlers.connected();
 
             // Monitor heartbeat feeds to see what Agents are online.
-            c.session.subscribe('observatory..feeds.heartbeat',
+            c.session.subscribe(addr_root + '..feeds.heartbeat',
                                 function (args, kwargs, details) { // eslint-disable-line
                                     var info = args[0][1];
                                     this_ocs.agent_list._heartbeat(info);

--- a/src/ocsweb.js
+++ b/src/ocsweb.js
@@ -77,32 +77,45 @@ function get_status_string(session) {
     return t;
 }
 
+function clean_config(item) {
+  /** For a crossbar config block, fill in realm and addr_root, if
+   * missing. */
+  if (!item.realm)
+    item.realm = 'test_realm';
+  if (!item.addr_root)
+    item.addr_root = 'observatory';
+  return item;
+}
+
 export
 function setup_configs() {
   let configs = [];
 
   // Decode environment var ... expecting format
-  // "name1,url1,realm1;name2,url2,realm2;..."
+  //   "name1,url1,realm1,addr_root1;name2,url2,realm2,addr_root2;..."
+  // Ok if missing realm or realm and addr_root.
   let addrs = process.env.VUE_APP_OCS_ADDRS;
   if (addrs) {
     addrs.split(';').map(addr => {
-      let [name, url, realm] = addr.split(',');
-      configs.push({
-        name: name,
-        url: url,
-        realm: realm});
+      let item = {};
+      [item.name, item.url, item.realm, item.addr_root] = addr.split(',');
+      configs.push(clean_config(item));
     });
   }
 
+  // Parse entries in the config.json file.
   if (window.config.crossbars) {
-    window.config.crossbars.map((item) => configs.push(item));
+    window.config.crossbars.map((item) => {
+      configs.push(clean_config(item))
+    });
   }
 
+  // Push an editable item with default dev config.
   configs.push(
-    {'name': 'custom',
-     'url': 'ws://localhost:8001/ws',
-     'realm': 'test_realm',
-     'edit': true});
+    clean_config({'name': 'custom',
+                  'url': 'ws://localhost:8001/ws',
+                  'edit': true})
+  );
 
   return [configs, 0];
 }

--- a/src/panels/ConfigsWindow.vue
+++ b/src/panels/ConfigsWindow.vue
@@ -27,10 +27,16 @@
               @input="emitConfigChange(index, 'url', $event.target.value)"
             />
             <OpParam
-              caption="Realm"
+              caption="WAMP Realm"
               :modelDisabled="!config.edit"
               :modelValue="config.realm"
-              @input="emitConfigChange()"
+              @input="emitConfigChange(index, 'realm', $event.target.value)"
+            />
+            <OpParam
+              caption="OCS Address Root"
+              :modelDisabled="!config.edit"
+              :modelValue="config.addr_root"
+              @input="emitConfigChange(index, 'addr_root', $event.target.value)"
             />
           </form>
         </div>


### PR DESCRIPTION
- Enables configuration of OCS address root through all the config channels.
- Fixes a bug in saving "custom" block's realm (and address root).
- Puts the config name in the title at the top of the window.