### PR TITLE
ACU: add indicators for Axis faults (summary and comp disabled)

### DIFF
--- a/agent/acuagent.yaml
+++ b/agent/acuagent.yaml
@@ -7,6 +7,7 @@ processes:
       'timestamp_field': 'timestamp'
       }
     data: {
+      "PlatformType": 'satp',
       "StatusDetailed": {
         "Time": 51.709323698652,
         "Year": 2023,
@@ -34,7 +35,7 @@ processes:
         "Azimuth CW limit: operating": false,
         "Azimuth CW limit: emergency": false,
         "Azimuth CW limit: 2nd emergency": false,
-        "Azimuth summary fault": false,
+        "Azimuth summary fault": true,
         "Azimuth servo failure": false,
         "Azimuth motion error": false,
         "Azimuth brake 1 failure": false,

--- a/src/panels/ACUAgent.vue
+++ b/src/panels/ACUAgent.vue
@@ -62,6 +62,18 @@
           />
         </OcsLightLine>
 
+        <OcsLightLine caption="Axis Faults">
+          <template v-for="item in axisFaultLights" v-bind:key="item.name">
+            <OcsLight
+              :caption='item.name'
+              type="multi"
+              :tip="'Will show green/good if not &quot;' + item.key + '&quot;.'"
+              :value="getIndicator('-', item.key)"
+              v-if="!item.feature || platformFeature(item.feature)"
+            />
+          </template>
+        </OcsLightLine>
+
         <h2>Pointing</h2>
         <OpReading
           caption="Activity"
@@ -318,6 +330,29 @@
     inject: ['accessLevel'],
     data: function () {
       return {
+        dev_mode: false,
+        axisFaultLights: [
+          {name: 'El Sum',
+           key: 'Elevation summary fault'},
+          {name: 'El Comp',
+           key: 'Elevation computer disabled'},
+          {name: 'Az Sum',
+           key: 'Azimuth summary fault'},
+          {name: 'Az Comp',
+           key: 'Azimuth computer disabled'},
+          {name: 'BS Sum',
+           key: 'Boresight summary fault',
+           feature: 'boresight'},
+          {name: 'BS Comp',
+           key: 'Boresight computer disabled',
+           feature: 'boresight'},
+          {name: 'CR Sum',
+           key: 'Corotator summary fault',
+           feature: 'corotator'},
+          {name: 'CR Comp',
+           key: 'Corotator computer disabled',
+           feature: 'corotator'},
+        ],
         panel: {},
         ops: window.ocs_bundle.web.ops_data_init({
           go_to: {
@@ -499,7 +534,7 @@
         return (window.ocs_bundle.util.pad_decimal(pos.toFixed(4), 5, ' ') +
                 ' [' + mode + ']');
       },
-      getIndicator(name) {
+      getIndicator(name, mon_key) {
         let mon_stale_time = 3;  // Seems to be enough
         let brd_stale_time = 5;  // 3 is not enough.
 
@@ -536,6 +571,9 @@
         let mon_stale = !mon_time || (
           window.ocs_bundle.util.timestamp_now() - mon_time > mon_stale_time);
 
+        if (this.dev_mode)
+          mon_stale = false;
+
         if (name == 'monitor') {
           if (mon_running && mon_stale)
             return 'warning';
@@ -552,7 +590,11 @@
           case 'remote':
             return detail['ACU in remote mode'];
           case 'summary':
-              return !detail['General summary fault'];
+            return !detail['General summary fault'];
+          case '+':
+            return detail[mon_key] === true;
+          case '-':
+            return detail[mon_key] === false;
         }
 
         return 'notapplic';

--- a/src/panels/ACUAgent.vue
+++ b/src/panels/ACUAgent.vue
@@ -46,19 +46,19 @@
             caption="UNLOCKED"
             type="multi"
             tip="Will show green/good when remote control is not locked out (Safe)."
-            :value="getIndicator('safe')"
+            :value="getIndicator('-', 'Safe')"
           />
           <OcsLight
             caption="REMOTE"
             type="multi"
             tip="Will show green/good when ACU is in Remote (rather than Local) control mode."
-            :value="getIndicator('remote')"
+            :value="getIndicator('+', 'ACU in remote mode')"
           />
           <OcsLight
             caption="READY"
             type="multi"
             tip="Will show green/good unless ACU expresses a General summary fault."
-            :value="getIndicator('summary')"
+            :value="getIndicator('-', 'General summary fault')"
           />
         </OcsLightLine>
 
@@ -330,7 +330,7 @@
     inject: ['accessLevel'],
     data: function () {
       return {
-        dev_mode: false,
+        dev_mode: false,  // DO NOT COMMIT THIS AS TRUE!
         axisFaultLights: [
           {name: 'El Sum',
            key: 'Elevation summary fault'},
@@ -584,13 +584,9 @@
         if (!mon_running || mon_stale)
           return 'notapplic';
 
+        // You could have short-hands for things ('safe' -> !detail['Safe'])
+        // but in many cases just look up directly in detail, and maybe negate.
         switch (name) {
-          case 'safe':
-              return !detail['Safe'];
-          case 'remote':
-            return detail['ACU in remote mode'];
-          case 'summary':
-            return !detail['General summary fault'];
           case '+':
             return detail[mon_key] === true;
           case '-':


### PR DESCRIPTION
Also: "dev_mode" setting, to pretend data aren't stale, and modify mocking agent schema to report PlatformType.